### PR TITLE
Fix git clone link and git submodule typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ This are HLSL examples of how to use [LYGIA Shader Library](https://github.com/p
 To use it make sure you clone this repository recursivelly.
 
 ```bash
-git clone --recursive https://github.com/patriciogonzalezvivo/lygia_examples.git
+git clone --recursive https://github.com/patriciogonzalezvivo/lygia_unity_examples.git
 ```
 
 Or if you already clone it, make sure you clone the submodules as well
 
 ```bash
-git submodules init
-git submodules update
+git submodule init
+git submodule update
 git pull
 ```


### PR DESCRIPTION
Hi! 
Was wondering for a while why the Unity project I downloaded didn't import correctly, then I noticed the incorrect link in README.md. 

Updated it for you and also fixed a typo in `git submodule` command below it.